### PR TITLE
Manually fix the bom for release 6.3-pr3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
         <entando-plugin-jacms.version>6.2.72</entando-plugin-jacms.version>
         <entando-plugin-jpmail.version>6.2.12</entando-plugin-jpmail.version>
         <entando-plugin-jpversioning.version>6.2.13</entando-plugin-jpversioning.version>
-        <entando-plugin-jpseo.version>6.2.22</entando-plugin-jpseo.version>
+        <entando-plugin-jpseo.version>6.2.23</entando-plugin-jpseo.version>
         <entando-plugin-jpcontentscheduler.version>6.2.11</entando-plugin-jpcontentscheduler.version>
-        <entando.keycloak.plugin.version>6.2.2</entando.keycloak.plugin.version>
+        <entando.keycloak.plugin.version>6.2.5</entando.keycloak.plugin.version>
         <github.organization>entando-k8s-infrastructure</github.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>${github.organization}</sonar.organization>


### PR DESCRIPTION
jpseo and keycloak plugins were not automatically updated by the pipelines